### PR TITLE
added AdminClientConfig in KafkaOptions

### DIFF
--- a/src/KafkaHubLifetimeManager.cs
+++ b/src/KafkaHubLifetimeManager.cs
@@ -311,9 +311,9 @@ public class KafkaHubLifetimeManager<THub> : HubLifetimeManager<THub>, IDisposab
         _consumer?.Dispose();
     }
 
-    private async Task InitTopics(string bootstrapServers, KafkaTopicConfig kafkaTopicConfig)
+    private async Task InitTopics(KafkaOptions options, KafkaTopicConfig kafkaTopicConfig)
     {
-        using var adminClient = new AdminClientBuilder(new AdminClientConfig { BootstrapServers = bootstrapServers }).Build();
+        using var adminClient = new AdminClientBuilder(options.AdminConfig).Build();
         var topics = new List<TopicSpecification>()
         {
             kafkaTopicConfig.AckSpecification,
@@ -350,7 +350,7 @@ public class KafkaHubLifetimeManager<THub> : HubLifetimeManager<THub>, IDisposab
             if (_kafkaInitialized) 
                 return;
 
-            InitTopics(producerConfig.BootstrapServers, options.KafkaTopicConfig).GetAwaiter().GetResult();
+            InitTopics(options, options.KafkaTopicConfig).GetAwaiter().GetResult();
             var producerBuilder = new ProducerBuilder<string, byte[]>(producerConfig)
                 .SetLogHandler((_, logMessage) =>
                 {

--- a/src/KafkaOptions.cs
+++ b/src/KafkaOptions.cs
@@ -6,6 +6,9 @@ namespace Ascentis.SignalR.Kafka;
 public class KafkaOptions
 {
     [Required]
+    public AdminClientConfig AdminConfig { get; set; }
+
+    [Required]
     public ConsumerConfig ConsumerConfig { get; set; }
 
     [Required]

--- a/test/Ascentis.SignalR.Kafka.IntegrationTests.Server/Startup.cs
+++ b/test/Ascentis.SignalR.Kafka.IntegrationTests.Server/Startup.cs
@@ -33,6 +33,10 @@ public class Startup
                     BootstrapServers = bootstrapServers,
                     ClientId = $"{Environment.MachineName}_{Guid.NewGuid():N}"
                 };
+                options.AdminConfig = new AdminClientConfig
+                {
+                    BootstrapServers = bootstrapServers
+                };
                 options.KafkaTopicConfig = new KafkaTopicConfig(
                     ackSpecification: new KafkaTopicSpecification
                     {


### PR DESCRIPTION
I set the AdminClientConfig as required in KafkaOptions. You could probably refactor the options to just take a base `Confluent.Kafka.ClientConfig` object and add any options needed.